### PR TITLE
Add account.entries.with_running_balance

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--colour
+--format documentation

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: ruby
-before_install: gem update --system
+dist: xenial
+before_install:
+  - gem update --system
 cache: bundler
 sudo: false
 rvm:
   - 2.5.1
-script: bundle exec rake
+script: bundle exec rspec
+addons:
+  apt:
+    update: true
+    packages:
+      - sqlite3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: ruby
-dist: xenial
-before_install:
-  - gem update --system
 cache: bundler
 sudo: false
+addons:
+  postgresql: '9.6'
 rvm:
   - 2.5.1
-script: bundle exec rspec
-addons:
-  apt:
-    update: true
-    packages:
-      - sqlite3
+before_install:
+  - gem update --system
+before_script:
+  - bundle exec rake app:db:test:prepare RAILS_ENV=test
+script:
+  - bundle exec rspec spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
-# Not Released
-## Fixed
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Add `account.entries.with_running_balance` association proxy method
+- Add `pry-byebug` in `Gemfile` for local development
+
+## [0.1.0]
+### Fixed
 - Fix loading of jquery-ui files (Fixes https://github.com/mbulat/borutus/issues/58)
 
-## Added
+### Added
 - Add `Account#amounts` and `Account#entries` to get all amounts and entries, respectively
 
-## Changed
+### Changed
 - How migrations are done, which may be a breaking change from older versions of Borutus. When upgrading to this version, run `rake borutus:install:migrations`, and ensure that the files that are generated are of migrations you only need. It should not generate new versions if you've installed the latest version before this.

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,5 @@ group :development, :test do
   gem "rspec-its"
   gem "rspec-rails", "~> 3"
   gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
+  gem "pg", "~> 1.1"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,17 @@
-source 'http://rubygems.org'
+source "http://rubygems.org"
 
 # Specify your gem's dependencies in borutus.gemspec
 gemspec
 
 group :development, :test do
-  gem 'activerecord-jdbcsqlite3-adapter', :require => 'jdbc-sqlite3', :platform => :jruby
-  gem 'coveralls', require: false
-  gem 'factory_girl_rails', '~> 1.1'
-  gem 'jdbc-sqlite3', :platform => :jruby
-  gem 'rails-controller-testing'
-  gem 'rspec', '~> 3'
-  gem 'rspec-its'
-  gem 'rspec-rails', '~> 3'
-  gem 'sqlite3', :platform => [:ruby, :mswin, :mingw]
+  gem "activerecord-jdbcsqlite3-adapter", require: "jdbc-sqlite3", platform: :jruby
+  gem "coveralls", require: false
+  gem "factory_girl_rails", "~> 1.1"
+  gem "jdbc-sqlite3", platform: :jruby
+  gem "pry-byebug"
+  gem "rails-controller-testing"
+  gem "rspec", "~> 3"
+  gem "rspec-its"
+  gem "rspec-rails", "~> 3"
+  gem "sqlite3", :platform => [:ruby, :mswin, :mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    pg (1.1.3)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -207,6 +208,7 @@ DEPENDENCIES
   coveralls
   factory_girl_rails (~> 1.1)
   jdbc-sqlite3
+  pg (~> 1.1)
   pry-byebug
   rails-controller-testing
   rspec (~> 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,8 @@ GEM
       tzinfo (~> 1.1)
     arel (9.0.0)
     builder (3.2.3)
+    byebug (10.0.2)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     coveralls (0.8.22)
       json (>= 1.8, < 3)
@@ -107,6 +109,12 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     rack (2.0.5)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -199,6 +207,7 @@ DEPENDENCIES
   coveralls
   factory_girl_rails (~> 1.1)
   jdbc-sqlite3
+  pry-byebug
   rails-controller-testing
   rspec (~> 3)
   rspec-its
@@ -208,4 +217,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Compatibility
 =============
 
 * Rails versions: ~> 5.0
+* PostgreSQL: > 9.4
 
 Installation
 ============
@@ -325,7 +326,9 @@ mount Borutus::Engine => "/borutus", :as => "borutus"
 Testing
 =======
 
-[Rspec](http://rspec.info/) tests are provided. Run `bundle install` then `rake`.
+Run `docker-compose up pg`, this will create a local postgresql database. Then create a DB name `borutus_fixture_test`, you can do this via `createdb --username=postgres --host=localhost --port=5432 --template=template0 borutus_fixture_test`
+
+[Rspec](http://rspec.info/) tests are provided. Run `bundle install` then `bundle exec rspec spec`.
 
 Contributing and Contributors
 =============================

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,17 @@
 require 'bundler/setup'
 
-APP_RAKEFILE = File.expand_path("./fixture_rails_root/Rakefile")
+APP_RAKEFILE = File.expand_path('./fixture_rails_root/Rakefile')
 load 'rails/tasks/engine.rake'
 load 'rails/tasks/statistics.rake'
 
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
-desc "run specs"
+desc 'run specs'
+
 RSpec::Core::RakeTask.new do |t|
-  t.rspec_opts = ["-c", "-f d", "-r ./spec/spec_helper.rb"]
+  t.rspec_opts = ['-c', '-f d', '-r ./spec/spec_helper.rb']
   t.pattern = 'spec/**/*_spec.rb'
 end
 
-task :default  => :spec
+task default: :spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,10 @@
 require 'bundler/setup'
 
+APP_RAKEFILE = File.expand_path("./fixture_rails_root/Rakefile")
+load 'rails/tasks/engine.rake'
+load 'rails/tasks/statistics.rake'
+
+require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
 desc "run specs"

--- a/app/models/borutus/account.rb
+++ b/app/models/borutus/account.rb
@@ -35,7 +35,45 @@ module Borutus
     has_many :amounts
     has_many :credit_amounts, :extend => AmountsExtension, :class_name => 'Borutus::CreditAmount'
     has_many :debit_amounts, :extend => AmountsExtension, :class_name => 'Borutus::DebitAmount'
-    has_many :entries, through: :amounts, source: :entry
+    has_many :entries, through: :amounts, source: :entry do
+      def with_running_balance
+        account = proxy_association.owner
+        credit_amounts = account.credit_amounts
+        debit_amounts = account.debit_amounts
+
+        credit_table = credit_amounts.joins(:entry).select(
+          :id,
+          :entry_id,
+          %{ SUM("borutus_amounts".amount) AS amount }
+        ).group(:entry_id, :id)
+
+        debit_table = debit_amounts.joins(:entry).select(
+          :id,
+          :entry_id,
+          %{ SUM("borutus_amounts".amount) AS amount }
+        ).group(:entry_id, :id)
+
+        select_statement = if account.normal_credit_balance
+                             %{ COALESCE("credit_table"."amount", 0) - coalesce("debit_table"."amount", 0) }
+                           else
+                             %{ COALESCE("debit_table"."amount", 0) - coalesce("credit_table"."amount", 0) }
+                           end
+
+        joins(%{
+          LEFT OUTER JOIN (#{credit_table.to_sql}) AS "credit_table" ON "credit_table".entry_id = "borutus_entries".id
+          LEFT OUTER JOIN (#{debit_table.to_sql}) AS "debit_table" ON "debit_table".entry_id = "borutus_entries".id
+        }).select(%{
+          "borutus_entries".*,
+          SUM(#{select_statement}) OVER(ORDER BY "borutus_entries"."created_at") AS balance
+        }).group(
+          :id,
+          %{
+            "debit_table".amount,
+            "credit_table".amount
+          }
+        ).order(created_at: :asc)
+      end
+    end
     has_many :credit_entries, :through => :credit_amounts, :source => :entry, :class_name => 'Borutus::Entry'
     has_many :debit_entries, :through => :debit_amounts, :source => :entry, :class_name => 'Borutus::Entry'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  pg:
+    image: postgres:9.6
+    ports:
+      - "5432:5432"
+    volumes:
+      - pg:/var/lib/postgresql/data
+volumes:
+  pg:

--- a/fixture_rails_root/Gemfile
+++ b/fixture_rails_root/Gemfile
@@ -10,6 +10,7 @@ end
 gem 'rails', '~> 5.1.2'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3'
+gem 'pg', '~> 1.1'
 # Use Puma as the app server
 gem 'puma', '~> 3.0'
 # Use SCSS for stylesheets

--- a/fixture_rails_root/Gemfile.lock
+++ b/fixture_rails_root/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    borutus (0.13)
+    borutus (0.1.0)
       jquery-rails (>= 3.0)
       jquery-ui-rails (>= 4.2.2)
       kaminari (~> 1.0)
@@ -103,6 +103,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
+    pg (1.1.3)
     puma (3.8.2)
     rack (2.0.3)
     rack-test (0.6.3)
@@ -177,12 +178,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  borutus!
   byebug
   coffee-rails (~> 4.2)
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
-  borutus!
+  pg (~> 1.1)
   puma (~> 3.0)
   rails (~> 5.1.2)
   sass-rails (~> 5.0)
@@ -195,4 +197,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/fixture_rails_root/config/database.yml
+++ b/fixture_rails_root/config/database.yml
@@ -5,21 +5,17 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
+  username: postgres
+  password:
+  host: localhost
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: borutus_fixture_dev
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
-
-production:
-  <<: *default
-  database: db/production.sqlite3
+  database: borutus_fixture_test

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,4 +1,0 @@
---colour
---format progress
---loadby mtime
---reverse

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,23 +1,34 @@
 require 'coveralls'
-require 'pry'
 Coveralls.wear!
 
-ENV["RAILS_ENV"] ||= 'test'
-require File.expand_path(File.dirname(__FILE__) + "/../fixture_rails_root/config/environment")
+require 'pry'
 
+ENV["RAILS_ENV"] ||= 'test'
+
+require File.expand_path(File.dirname(__FILE__) + "/../fixture_rails_root/config/environment")
 require Rails.root.join('db/schema').to_s
+
 require 'rspec/rails'
 
 $: << File.expand_path(File.dirname(__FILE__) + '/../lib/')
+
 require 'borutus'
 require 'kaminari'
 
-Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
+Dir[
+  File.expand_path(
+    File.join(File.dirname(__FILE__), 'support', '**', '*.rb')
+  )
+].each do |f|
+  require f
+end
 
 require 'factory_girl'
-borutus_definitions = File.expand_path(File.join(File.dirname(__FILE__), 'factories'))
-FactoryGirl.definition_file_paths << borutus_definitions
 
+borutus_definitions = File.expand_path(
+  File.join(File.dirname(__FILE__), 'factories')
+)
+FactoryGirl.definition_file_paths << borutus_definitions
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'coveralls'
+require 'pry'
 Coveralls.wear!
 
 ENV["RAILS_ENV"] ||= 'test'


### PR DESCRIPTION
This feature adds a method to accounts that allows you to list entries along with a `balance` column like so:

```
receivable = Borutus::Account.find_by name: "Accounts Receivable"
receivable.entries.with_running_balance
# Returns Entry model with a balance snapshot on the time of the entry
```
