### PR TITLE
Use unambiguous arel code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Use unambiguous `Account#with_amounts` scope
+
 ## [0.2.3] - 2019-10-25
 ### Fixed
 - Fix `AddBorutusAmountCounterCache` migration

--- a/app/models/borutus/account.rb
+++ b/app/models/borutus/account.rb
@@ -72,7 +72,7 @@ module Borutus
     validates_presence_of :type
 
     scope :with_amounts, -> do
-      where("amounts_count > 0")
+      where(arel_table[:amounts_count].gt(0))
     end
 
     def self.types


### PR DESCRIPTION
When referencing multiple tables in one SQL call, there won't be any doubt as to which table is being referred to if the scope is done this way